### PR TITLE
Queue: Add json_arguments parameter

### DIFF
--- a/rabbitmq/resource_queue.go
+++ b/rabbitmq/resource_queue.go
@@ -56,10 +56,10 @@ func resourceQueue() *schema.Resource {
 						"arguments": &schema.Schema{
 							Type:          schema.TypeMap,
 							Optional:      true,
-							ConflictsWith: []string{"settings.0.json_arguments"},
+							ConflictsWith: []string{"settings.0.arguments_json"},
 						},
 
-						"json_arguments": &schema.Schema{
+						"arguments_json": &schema.Schema{
 							Type:          schema.TypeString,
 							Optional:      true,
 							ValidateFunc:  validateJsonString,
@@ -84,16 +84,16 @@ func CreateQueue(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Unable to parse settings")
 	}
 
-	// If json_arguments is used, unmarshal it into a generic interface
+	// If arguments_json is used, unmarshal it into a generic interface
 	// and use it as the "arguments" key for the queue.
-	if v, ok := settingsMap["json_arguments"].(string); ok && v != "" {
+	if v, ok := settingsMap["arguments_json"].(string); ok && v != "" {
 		var arguments interface{}
 		err := json.Unmarshal([]byte(v), &arguments)
 		if err != nil {
 			return err
 		}
 
-		delete(settingsMap, "json_arguments")
+		delete(settingsMap, "arguments_json")
 		settingsMap["arguments"] = arguments
 	}
 

--- a/rabbitmq/resource_queue.go
+++ b/rabbitmq/resource_queue.go
@@ -1,6 +1,7 @@
 package rabbitmq
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"strings"
@@ -53,8 +54,16 @@ func resourceQueue() *schema.Resource {
 						},
 
 						"arguments": &schema.Schema{
-							Type:     schema.TypeMap,
-							Optional: true,
+							Type:          schema.TypeMap,
+							Optional:      true,
+							ConflictsWith: []string{"settings.0.json_arguments"},
+						},
+
+						"json_arguments": &schema.Schema{
+							Type:          schema.TypeString,
+							Optional:      true,
+							ValidateFunc:  validateJsonString,
+							ConflictsWith: []string{"settings.0.arguments"},
 						},
 					},
 				},
@@ -73,6 +82,19 @@ func CreateQueue(d *schema.ResourceData, meta interface{}) error {
 	settingsMap, ok := settingsList[0].(map[string]interface{})
 	if !ok {
 		return fmt.Errorf("Unable to parse settings")
+	}
+
+	// If json_arguments is used, unmarshal it into a generic interface
+	// and use it as the "arguments" key for the queue.
+	if v, ok := settingsMap["json_arguments"].(string); ok && v != "" {
+		var arguments interface{}
+		err := json.Unmarshal([]byte(v), &arguments)
+		if err != nil {
+			return err
+		}
+
+		delete(settingsMap, "json_arguments")
+		settingsMap["arguments"] = arguments
 	}
 
 	if err := declareQueue(rmqc, vhost, name, settingsMap); err != nil {

--- a/rabbitmq/resource_queue_test.go
+++ b/rabbitmq/resource_queue_test.go
@@ -149,6 +149,6 @@ resource "rabbitmq_queue" "test" {
     settings {
         durable = false
         auto_delete = true
-        json_arguments = "${var.arguments}"
+        arguments_json = "${var.arguments}"
     }
 }`

--- a/rabbitmq/util.go
+++ b/rabbitmq/util.go
@@ -1,6 +1,9 @@
 package rabbitmq
 
 import (
+	"encoding/json"
+	"fmt"
+
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -11,4 +14,34 @@ func checkDeleted(d *schema.ResourceData, err error) error {
 	}
 
 	return err
+}
+
+// pulled from terraform-provider-aws/aws/validators.go
+func validateJsonString(v interface{}, k string) (ws []string, errors []error) {
+	if _, err := normalizeJsonString(v); err != nil {
+		errors = append(errors, fmt.Errorf("%q contains invalid JSON: %s", k, err))
+	}
+	return
+}
+
+// pulled from terraform-provider-aws/aws/structure.go
+func normalizeJsonString(jsonString interface{}) (string, error) {
+	var j interface{}
+
+	if jsonString == nil || jsonString.(string) == "" {
+		return "", nil
+	}
+
+	s := jsonString.(string)
+
+	err := json.Unmarshal([]byte(s), &j)
+	if err != nil {
+		return s, err
+	}
+
+	// The error is intentionally ignored here to allow empty policies to passthrough validation.
+	// This covers any interpolated values
+	bytes, _ := json.Marshal(j)
+
+	return string(bytes[:]), nil
 }

--- a/website/docs/r/queue.html.markdown
+++ b/website/docs/r/queue.html.markdown
@@ -74,7 +74,7 @@ resource "rabbitmq_queue" "test" {
   settings {
     durable     = false
     auto_delete = true
-    json_arguments = "${var.arguments}"
+    arguments_json = "${var.arguments}"
   }
 }
 ```
@@ -100,9 +100,9 @@ The `settings` block supports:
 
 * `arguments` - (Optional) Additional key/value settings for the queue.
   All values will be sent to RabbitMQ as a string. If you require non-string
-  values, use `json_arguments`.
+  values, use `arguments_json`.
 
-* `json_arguments` - (Optional) A nested JSON string which contains additional
+* `arguments_json` - (Optional) A nested JSON string which contains additional
   settings for the queue. This is useful for when the arguments contain
   non-string values.
 

--- a/website/docs/r/queue.html.markdown
+++ b/website/docs/r/queue.html.markdown
@@ -12,6 +12,8 @@ The ``rabbitmq_queue`` resource creates and manages a queue.
 
 ## Example Usage
 
+### Basic Example
+
 ```hcl
 resource "rabbitmq_vhost" "test" {
   name = "test"
@@ -39,6 +41,44 @@ resource "rabbitmq_queue" "test" {
 }
 ```
 
+### Example With JSON Arguments
+
+```hcl
+variable "arguments" {
+  default = <<EOF
+{
+  "x-message-ttl": 5000
+}
+EOF
+}
+
+resource "rabbitmq_vhost" "test" {
+  name = "test"
+}
+
+resource "rabbitmq_permissions" "guest" {
+  user  = "guest"
+  vhost = "${rabbitmq_vhost.test.name}"
+
+  permissions {
+    configure = ".*"
+    write     = ".*"
+    read      = ".*"
+  }
+}
+
+resource "rabbitmq_queue" "test" {
+  name  = "test"
+  vhost = "${rabbitmq_permissions.guest.vhost}"
+
+  settings {
+    durable     = false
+    auto_delete = true
+    json_arguments = "${var.arguments}"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -59,6 +99,12 @@ The `settings` block supports:
   consumers have unsubscribed.
 
 * `arguments` - (Optional) Additional key/value settings for the queue.
+  All values will be sent to RabbitMQ as a string. If you require non-string
+  values, use `json_arguments`.
+
+* `json_arguments` - (Optional) A nested JSON string which contains additional
+  settings for the queue. This is useful for when the arguments contain
+  non-string values.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This commit adds the json_arguments parameter to the
rabbitmq_queue resource. This can accept a JSON string
which is useful for argument values which are not strings.

For #1 