### PR TITLE
Allow integer values for policy definitions

### DIFF
--- a/rabbitmq/resource_policy_test.go
+++ b/rabbitmq/resource_policy_test.go
@@ -108,6 +108,7 @@ resource "rabbitmq_policy" "test" {
         definition {
             ha-mode = "nodes"
             ha-params = "a,b,c"
+            max-length = 10000
         }
     }
 }`


### PR DESCRIPTION
This commit fixes a bug where policy definitions with integer
values were not working correctly due to their implicit cast
to a string.

This commit fixes it by detecting if a value is an integer and
setting it correctly in the API request body. Converting back
to a string when the value is read is also accounted for.

Fixes #12 