### PR TITLE
Read proxy configuration from environment

### DIFF
--- a/rabbitmq/provider.go
+++ b/rabbitmq/provider.go
@@ -113,7 +113,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	}
 
 	// Connect to RabbitMQ management interface
-	transport := &http.Transport{TLSClientConfig: tlsConfig}
+	transport := &http.Transport{TLSClientConfig: tlsConfig, Proxy: http.ProxyFromEnvironment}
 	rmqc, err := rabbithole.NewTLSClient(endpoint, username, password, transport)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
I'm not really familiar with go, but this seemed to get the provider working from behind a proxy.