### PR TITLE
Correctly handle "not found" errors

### DIFF
--- a/rabbitmq/util.go
+++ b/rabbitmq/util.go
@@ -4,12 +4,16 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/michaelklishin/rabbit-hole"
 )
 
 func checkDeleted(d *schema.ResourceData, err error) error {
-	if err.Error() == "not found" {
-		d.SetId("")
-		return nil
+	switch e := err.(type) {
+	case rabbithole.ErrorResponse:
+		if e.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 	}
 
 	return err


### PR DESCRIPTION
Probably during the rabbithole update from 7235f3, the errors has currently
checked by the provider don't correctly detect that a resource has gone
missing on the cluster.

This creates unexpected "404 Not Found" errors at the end of any
refresh/plan/apply/destroy if any of the resources previously created by
Terraform (and known in the Terraform state) has been removed from the
RabbitMQ cluster, outside of Terraform.

I only tested a few, but this should affect all the resources: queues,
exchanges, vhost, permissions, users and policies (verified only on
vhosts, permissions, users and policies).

In this case, the RabbitMQ provider tries to read the resource it created
in the past, receives a 404 response from the cluster but doesn't treat it
correctly and returns a generic response "404 Object Not Found".

This change tries to read the error as a rabbithole error and handle the
404 response correctly.


I added a basic test on the "vhost" resource to show that it's working correctly now. What I was trying to do was:

* Create an initial resource with Terraform.
* Make the resource "disappear" outside of Terraform.
* Reexecute the Terraform configuration and expect Terraform to recreate the resource correctly.

I'm not too familiar with Terraform providers so feel free to suggest an alternative way of doing so.
Also, I've only added a test on the vhost resource but the bug affects most if not all the resources. Let me know it that test looks OK and if you would like me to extend it to other resources as well.