### PR TITLE
rabbitmq_permissions: Fix error on empty permissions.

### DIFF
--- a/examples/test_issues_pr/42/test.tf
+++ b/examples/test_issues_pr/42/test.tf
@@ -1,0 +1,17 @@
+resource "rabbitmq_user" "test" {
+  name     = "test"
+  password = "foobar"
+  tags     = ["management"]
+}
+
+resource "rabbitmq_permissions" "test" {
+  user  = rabbitmq_user.test.name
+  vhost = "/"
+
+  permissions {
+    write     = ""
+    read      = ""
+    configure = ""
+  }
+}
+

--- a/rabbitmq/resource_permissions.go
+++ b/rabbitmq/resource_permissions.go
@@ -68,9 +68,9 @@ func CreatePermissions(d *schema.ResourceData, meta interface{}) error {
 	vhost := d.Get("vhost").(string)
 	permsList := d.Get("permissions").([]interface{})
 
-	permsMap, ok := permsList[0].(map[string]interface{})
-	if !ok {
-		return fmt.Errorf("Unable to parse permissions")
+	permsMap := map[string]interface{}{}
+	if permsList[0] != nil {
+		permsMap = permsList[0].(map[string]interface{})
 	}
 
 	if err := setPermissionsIn(rmqc, vhost, user, permsMap); err != nil {

--- a/rabbitmq/resource_permissions_test.go
+++ b/rabbitmq/resource_permissions_test.go
@@ -34,6 +34,43 @@ func TestAccPermissions(t *testing.T) {
 	})
 }
 
+func TestAccPermissions_Empty(t *testing.T) {
+
+	configCreate := `
+resource "rabbitmq_vhost" "test" {
+    name = "test"
+}
+
+resource "rabbitmq_user" "test" {
+    name = "mctest"
+    password = "foobar"
+}
+
+resource "rabbitmq_permissions" "test" {
+    user = rabbitmq_user.test.name
+    vhost = rabbitmq_vhost.test.name
+    permissions {
+        configure = ""
+        write = ""
+        read = ""
+    }
+}`
+	var permissionInfo rabbithole.PermissionInfo
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccPermissionsCheckDestroy(&permissionInfo),
+		Steps: []resource.TestStep{
+			{
+				Config: configCreate,
+				Check: testAccPermissionsCheck(
+					"rabbitmq_permissions.test", &permissionInfo,
+				),
+			},
+		},
+	})
+}
+
 func testAccPermissionsCheck(rn string, permissionInfo *rabbithole.PermissionInfo) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[rn]


### PR DESCRIPTION
We want to be able to create permissions for a user with no permissions.

e.g:
```

resource "rabbitmq_permissions" "readonly" {
  user  = "test"
  vhost = "/"

  permissions {
    configure = ""
    write     = ""
    read      = ""
  }
}
```

When putting only empty string, Terraform puts nil in the list of permissions object
instead of a map with 3 empty strings.

fix #42