### PR TITLE
rabbitmq_queue: Set ForceNew on all attributes

### DIFF
--- a/rabbitmq/resource_queue.go
+++ b/rabbitmq/resource_queue.go
@@ -46,12 +46,14 @@ func resourceQueue() *schema.Resource {
 							Type:     schema.TypeBool,
 							Optional: true,
 							Default:  false,
+							ForceNew: true,
 						},
 
 						"auto_delete": {
 							Type:     schema.TypeBool,
 							Optional: true,
 							Default:  false,
+							ForceNew: true,
 						},
 
 						"arguments": {

--- a/rabbitmq/resource_queue_test.go
+++ b/rabbitmq/resource_queue_test.go
@@ -25,6 +25,12 @@ func TestAccQueue_basic(t *testing.T) {
 					"rabbitmq_queue.test", &queueInfo,
 				),
 			},
+			{
+				Config: testAccQueueConfig_update,
+				Check: testAccQueueCheck(
+					"rabbitmq_queue.test", &queueInfo,
+				),
+			},
 		},
 	})
 }
@@ -144,6 +150,30 @@ resource "rabbitmq_queue" "test" {
     settings {
         durable = false
         auto_delete = true
+    }
+}`
+
+const testAccQueueConfig_update = `
+resource "rabbitmq_vhost" "test" {
+    name = "test"
+}
+
+resource "rabbitmq_permissions" "guest" {
+    user = "guest"
+    vhost = "${rabbitmq_vhost.test.name}"
+    permissions {
+        configure = ".*"
+        write = ".*"
+        read = ".*"
+    }
+}
+
+resource "rabbitmq_queue" "test" {
+    name = "test"
+    vhost = "${rabbitmq_permissions.guest.vhost}"
+    settings {
+        durable = true
+        auto_delete = false
     }
 }`
 


### PR DESCRIPTION
PR #38 added it on `arguments` attributes but actually we need it on all attributes
as a queue cannot be updated.

This fix #17

@aminueza As you seem to be quite motivated to work on this provider these days, I allow myself to ask for your help again for a little review :)