### PR TITLE
Drop support for RabbitMQ 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ env:
   jobs:
   - RABBITMQ_VERSION=3.8
   - RABBITMQ_VERSION=3.7
-  - RABBITMQ_VERSION=3.6
 
 install:
 # This script is used by the Travis build to install a cookie for

--- a/README.md
+++ b/README.md
@@ -31,11 +31,15 @@ $ make build
 ```
 
 Using the provider
-----------------------
-## Fill in for each provider
+------------------
+
+The provider supports verions `3.8.x` and `3.7.x` of RabbitMQ. It may still work with version`3.6.x`, however this version is no longer supported.
+
+For information on RabbitMQ versions, see the RabbitMQ [version documentation](https://www.rabbitmq.com/versions.html) and [changelog](https://www.rabbitmq.com/changelog.html).
+
 
 Developing the Provider
----------------------------
+-----------------------
 
 If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.11+ is *required*). You'll also need to correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.
 


### PR DESCRIPTION
### What this PR does:
* Removes the `RABBITMQ_VERSION=3.6` job from the travis build config.
* Adds information to the README on supported RabbitMQ versions.

### Why do we need this PR?

A [recent build failure](https://github.com/terraform-providers/terraform-provider-rabbitmq/pull/57) highlighted the need to clearly state which versions of RabbitMQ this provider supports. 

1. The library this provider is built on (`rabbit-hole`) only supports `3.8.x` and `3.7.x`.

2. Version `3.6.x` was [out of support by the vendor](https://www.rabbitmq.com/versions.html) on 31 May 2018 (that's 2 years ago), it makes sense to state support for `3.8.x` and `3.7.x` only.

As such, I have removed `3.6.x` from the Travis build. However, this provider may still work without issues against earlier versions of RabbitMQ. In fact, there remains some code to handle this version explicitly in the context of Topic Permissions, and that code should remain as is.